### PR TITLE
🔧 chore(build.yml): update Go version to 1.22 in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.23.4'
+          go-version: '1.22'
 
       - name: Install Go protobuf tools
         run: |

--- a/generated/go/v1/go.mod
+++ b/generated/go/v1/go.mod
@@ -1,4 +1,4 @@
-module github.com/oof-gg/oof-protobufs/generated/go
+module github.com/oof-gg/oof-protobufs
 
 go 1.22
 


### PR DESCRIPTION
🔄 chore(go.mod): remove version number from Go module declaration