### PR TITLE
addition of trending games rpc

### DIFF
--- a/protobuf/v1/api/common/game_service.proto
+++ b/protobuf/v1/api/common/game_service.proto
@@ -34,6 +34,9 @@ service GameService {
   /// Update a game by ID
   rpc UpdateGame (v1.api.game.GameUpdateRequest) returns (v1.api.game.StandardResponse);
 
+  /// Trending games
+  rpc TrendingGame (v1.api.game.TrendingGamesRequest) returns (v1.api.game.PaginatedResponse);
+
   /// Wait for queue updates
   rpc StreamEvents (stream v1.api.game.GameEvent) returns (v1.api.game.GameEvent);
   /// Stream events from the game

--- a/protobuf/v1/api/game/game.proto
+++ b/protobuf/v1/api/game/game.proto
@@ -43,6 +43,11 @@ message GameUpdateRequest {
   optional string data = 4;
 }
 
+message TrendingGamesRequest {
+  optional int32 limit = 1;
+  optional string cursor = 2;
+}
+
 message GameUpdateResponse {
   Game game = 1;
 }


### PR DESCRIPTION
This pull request introduces a new feature to the game service API by adding support for trending games. The most important changes include the addition of a new RPC method and the definition of a new request message.

New feature for trending games:

* [`protobuf/v1/api/common/game_service.proto`](diffhunk://#diff-70d8da37ca4f0dc6decd181ea7b09e3aacfe67e8bf8f5386097277bbb0274583R37-R39): Added a new RPC method `TrendingGame` to the `GameService` to handle requests for trending games.
* [`protobuf/v1/api/game/game.proto`](diffhunk://#diff-115cf020f0e0ce81dc67c4e616d4f7898e652941d896d3037bc557e710f82aebR46-R50): Defined a new message `TrendingGamesRequest` to support the new `TrendingGame` RPC method, including optional parameters `limit` and `cursor`.